### PR TITLE
Elements look the same and stay in place when reloading happens.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.4
+
+Reloaded element can exist anywhere in the DOM and stays in place when reloaded.
+
 # 1.0.3
 
 Fix hot reloading on pages other than index

--- a/index.js
+++ b/index.js
@@ -2,14 +2,13 @@ module.exports = function(source) {
   return source + `;
     if (module.hot) {
       var injectCss = function injectCss(prev, href) {
-        var link = document.createElement("link");
-        link.type = "text/css";
-        link.rel = "stylesheet";
+        var link = prev.cloneNode();
         link.href = href;
         link.onload = function() {
-          document.head.removeChild(prev);
+          prev.parentNode.removeChild(prev);
         };
-        document.head.appendChild(link);
+        prev.stale = true;
+        prev.parentNode.insertBefore(link, prev);
       };
       module.hot.dispose(function() {
         window.__webpack_reload_css__ = true;
@@ -21,7 +20,7 @@ module.exports = function(source) {
         document
           .querySelectorAll("link[href][rel=stylesheet]")
           .forEach(function(link) {
-            if (!link.href.match(prefix)) return;
+            if (!link.href.match(prefix) || link.stale) return;
             injectCss(link, link.href.split("?")[0] + "?unix=${+new Date()}");
           });
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extracted-loader",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Reloads stylesheets extracted with with ExtractTextPlugin",
   "main": "index.js",
   "files": ["index.js"],


### PR DESCRIPTION
This fixes #1.

The changes made were:

1. Using `[node].cloneNode()` to replicate the link element (so that attributes stay the same).
2. Keeping the element in-place (so that you can find it if you are viewing the DOM).
3. Trying to prevent the loader from re-examining elements. Because `document.querySelectorAll()` emits a NodeList the new elements will pop up and get re-processed. This is why I've tagged them with `.stale`.

🎁 Tried to update package.json and changelog appropriately as well to keep things easy. Hope this is ok. 😅 